### PR TITLE
Fix recursion in iterate_to_valid_point May Never Terminate #1

### DIFF
--- a/test/bdhke_test.exs
+++ b/test/bdhke_test.exs
@@ -63,6 +63,26 @@ defmodule BDHKETest do
     ]
   end
 
+  describe "hash_to_curve function tests" do
+    test "0x00" do
+      {:ok, secret_msg} = "0000000000000000000000000000000000000000000000000000000000000000" |> Base.decode16()
+      {:ok, %Point{} = point} = BDHKE.hash_to_curve(secret_msg)
+      assert Point.serialize_public_key(point)  == "024cce997d3b518f739663b757deaec95bcd9473c30a14ac2fd04023a739d1a725"
+    end
+
+    test "0x01" do
+      {:ok, secret_msg} = "0000000000000000000000000000000000000000000000000000000000000001" |> Base.decode16()
+      {:ok, %Point{} = point} = BDHKE.hash_to_curve(secret_msg)
+      assert Point.serialize_public_key(point)  == "022e7158e11c9506f1aa4248bf531298daa7febd6194f003edcd9b93ade6253acf"
+    end
+
+    test "0x02" do
+      {:ok, secret_msg} = "0000000000000000000000000000000000000000000000000000000000000002" |> Base.decode16()
+      {:ok, %Point{} = point} = BDHKE.hash_to_curve(secret_msg)
+      assert Point.serialize_public_key(point)  == "026cdbe15362df59cd1dd3c9c11de8aedac2106eca69236ecd9fbe117af897be4f"
+    end
+  end
+
   describe "Blind DH Key exchange" do
     test "hash a message to the curve", context do
       {:ok, %Point{} = point} = BDHKE.hash_to_curve(context[:secret_msg])


### PR DESCRIPTION
### Pull Request: Improve `iterate_to_valid_point` and Enhance `hash_to_curve`

#### Changes:
1. **Fix `iterate_to_valid_point` recursion**:
   - Added a `counter` limit to prevent infinite recursion.
   - The function now stops after the limit is reached, returning an error if no valid point is found.

2. **Configurable separator in `hash_to_curve`**:
   - `hash_to_curve` now accepts a configurable separator, making it more flexible.

3. **Iteration counter in `hash_to_curve`**:
   - The hash generation now includes the iteration counter to ensure unique results across iterations.

4. **Tests ported from Nutshell**:
   - Tests for `hash_to_curve` have been ported from the Nutshell project to ensure functionality and reliability.