### PR TITLE
Add tests for the Cashu module

### DIFF
--- a/lib/bdhke.ex
+++ b/lib/bdhke.ex
@@ -46,8 +46,6 @@ defmodule Cashu.BDHKE do
 
   def blind_point(secret_msg, blinding_factor)
       when is_binary(secret_msg) and is_binary(blinding_factor) do
-    secret_msg = Base.decode16!(secret_msg, case: :lower)
-
     {:ok, blinding_factor} = blinding_factor |> String.to_integer(16) |> PrivateKey.new()
     blind_point(secret_msg, blinding_factor)
   end
@@ -89,7 +87,13 @@ defmodule Cashu.BDHKE do
     By substracting her blinding factor from c_ , she "unblinds" the signature on her secret message.
     This is your ecash token.
   """
-  def generate_proof(c_, r, a_point) do
+  def generate_proof(c_, r, a_point) when is_binary(c_) and is_binary(r) do
+    {:ok, c_} = Point.parse_public_key(c_)
+    r = String.to_integer(r, 16)
+    generate_proof(c_, r, a_point)
+  end
+
+  def generate_proof(%Point{} = c_, r, %Point{} = a_point) do
     case a_point
          |> Math.multiply(r)
          |> negate() do

--- a/lib/models/blinded_message.ex
+++ b/lib/models/blinded_message.ex
@@ -6,7 +6,6 @@ defmodule Cashu.BlindedMessage do
   alias Cashu.{BDHKE, Validator}
   alias Bitcoinex.Secp256k1.Point
 
-  @derive Jason.Encoder
   defstruct id: nil, amount: 0, b_prime: nil
 
   @type t :: %{
@@ -24,7 +23,7 @@ defmodule Cashu.BlindedMessage do
     case BDHKE.blind_point(secret_message) do
       {:ok, blind_point, _blinding_factor} ->
         hex_point = Point.serialize_public_key(blind_point)
-        new(%{amount: amount, id: keyset_id, b_: hex_point})
+        new(%{amount: amount, id: keyset_id, b_prime: hex_point})
 
       {:error, _reason} ->
         {:error, "Blind point error"}
@@ -44,4 +43,17 @@ defmodule Cashu.BlindedMessage do
   end
 
   def validate_bm_list(list), do: Validator.validate_list(list, &validate/1)
+end
+
+defimpl Jason.Encoder, for: Cashu.BlindedMessage do
+  def encode(struct, opts) do
+    Jason.Encode.keyword(
+      [
+        amount: struct.amount,
+        id: struct.id,
+        "B_": struct.b_prime
+      ],
+      opts
+    )
+  end
 end

--- a/lib/models/blinded_message.ex
+++ b/lib/models/blinded_message.ex
@@ -6,35 +6,44 @@ defmodule Cashu.BlindedMessage do
   alias Cashu.{BDHKE, Validator}
   alias Bitcoinex.Secp256k1.Point
 
-  defstruct id: nil, amount: 0, b_prime: nil
+  defstruct id: nil, amount: 0, b_prime: nil, blinding_factor: nil, secret: nil
 
   @type t :: %{
-    id: String.t(),
-    amount: pos_integer(),
-    b_prime: binary()
-  }
+          id: String.t(),
+          amount: pos_integer(),
+          b_prime: binary(),
+          blinding_factor: pos_integer(),
+          secret: binary()
+        }
 
   def new(), do: %__MODULE__{}
   def new(params) when is_list(params), do: struct!(__MODULE__, params)
   def new(params) when is_map(params), do: Map.to_list(params) |> new()
 
-  def new(amount, secret_message, keyset_id)
-      when is_integer(amount) and is_binary(secret_message) do
-    case BDHKE.blind_point(secret_message) do
-      {:ok, blind_point, _blinding_factor} ->
+  def new(amount, secret_message, blinding_factor_hex, keyset_id)
+      when is_integer(amount) and is_binary(secret_message) and is_binary(blinding_factor_hex) do
+    case BDHKE.blind_point(secret_message, blinding_factor_hex) do
+      {:ok, blind_point, blinding_factor} ->
         hex_point = Point.serialize_public_key(blind_point)
-        new(%{amount: amount, id: keyset_id, b_prime: hex_point})
+
+        new(%{
+          amount: amount,
+          id: keyset_id,
+          b_prime: hex_point,
+          blinding_factor: blinding_factor,
+          secret: secret_message
+        })
 
       {:error, _reason} ->
         {:error, "Blind point error"}
     end
   end
 
-  def new(_, _, _), do: {:error, :invalid_params}
+  def new(_, _, _, _), do: {:error, :invalid_params}
 
   def validate(%__MODULE__{amount: amount, id: id, b_prime: b_} = bm) do
-    with {:ok , _} <- Validator.validate_amount(amount),
-         {:ok, _}<- Validator.validate_id(id),
+    with {:ok, _} <- Validator.validate_amount(amount),
+         {:ok, _} <- Validator.validate_id(id),
          {:ok, _} <- Validator.validate_b_(b_) do
       {:ok, bm}
     else
@@ -51,7 +60,7 @@ defimpl Jason.Encoder, for: Cashu.BlindedMessage do
       [
         amount: struct.amount,
         id: struct.id,
-        "B_": struct.b_prime
+        B_: struct.b_prime
       ],
       opts
     )

--- a/lib/models/blinded_signature.ex
+++ b/lib/models/blinded_signature.ex
@@ -19,11 +19,11 @@ defmodule Cashu.BlindedSignature do
   def new(params) when is_list(params), do: struct!(__MODULE__, params)
   def new(params) when is_map(params), do: Map.to_list(params) |> new()
 
-  def new(blinded_message, keyset_id, mint_privkey) do
+  def new(blinded_message, amount, keyset_id, mint_privkey) do
     case BDHKE.sign_blinded_point(blinded_message, mint_privkey) do
       {:ok, commitment_point, _e, _s} ->
         hex_c_ = Point.serialize_public_key(commitment_point)
-        new(%{amount: blinded_message.amount, id: keyset_id, c_: hex_c_})
+        new(%{amount: amount, id: keyset_id, c_prime: hex_c_})
 
       {:error, reason} ->
         {:error, reason}

--- a/lib/models/keyset.ex
+++ b/lib/models/keyset.ex
@@ -19,7 +19,6 @@ defmodule Cashu.Keyset do
           id: String.t(),
           active: boolean(),
           unit: String.t(),
-          input_fee_ppk: pos_integer(),
           keys: mint_pubkeys()
         }
 

--- a/lib/models/proof_v4.ex
+++ b/lib/models/proof_v4.ex
@@ -9,8 +9,9 @@ defmodule Cashu.ProofV4 do
   @derive Jason.Encoder
   defstruct keyset_id: "", amount: 0, secret: "", signature: "", witness: nil, dleq_proof: nil
 
+  # FIXME bad typing
   @type t :: %{
-          id: String.t(),
+          keyset_id: String.t(),
           amount: pos_integer(),
           secret: String.t(),
           signature: String.t(),
@@ -25,7 +26,7 @@ defmodule Cashu.ProofV4 do
     case BDHKE.generate_proof(c_, secret, mint_pubkey) do
       {:ok, %Point{} = c} ->
         hex_c = Point.serialize_public_key(c)
-        new(amount: amount, id: keyset_id, secret: secret, C: hex_c)
+        new(amount: amount, keyset_id: keyset_id, secret: secret, signature: hex_c)
 
       {:error, reason} ->
         Error.new(reason)

--- a/lib/models/proof_v4.ex
+++ b/lib/models/proof_v4.ex
@@ -22,8 +22,8 @@ defmodule Cashu.ProofV4 do
   def new(params) when is_list(params), do: struct!(__MODULE__, params)
   def new(params) when is_map(params), do: Map.to_list(params) |> new()
 
-  def new(c_, secret, amount, keyset_id, mint_pubkey) do
-    case BDHKE.generate_proof(c_, secret, mint_pubkey) do
+  def new(c_, blinding_factor, secret, amount, keyset_id, mint_pubkey) do
+    case BDHKE.generate_proof(c_, blinding_factor, mint_pubkey) do
       {:ok, %Point{} = c} ->
         hex_c = Point.serialize_public_key(c)
         new(amount: amount, keyset_id: keyset_id, secret: secret, signature: hex_c)

--- a/test/bdhke_test.exs
+++ b/test/bdhke_test.exs
@@ -1,0 +1,24 @@
+defmodule Cashu.BDHKETest do
+  alias Bitcoinex.Secp256k1.PrivateKey
+  alias Bitcoinex.Secp256k1.Point
+  alias Cashu.BDHKE
+  use ExUnit.Case
+
+  describe "generate_proof/3" do
+    test "test 01" do
+      c_ = "02f808cc3ba75657fa591a43fce914297eb993fe7cea34e8b5438c5024d8ad4069"
+      r = "b41576276b780b9467a634a02d21e14d0ecec280be82b14444764177030c6d81"
+
+      {:ok, mint_privkey} =
+        "c792bf68fa82a5002348fa0e58e4dd201f5910231f4e08271924699c9268177a"
+        |> Integer.parse(16)
+        |> elem(0)
+        |> PrivateKey.new()
+
+      {:ok, c} = BDHKE.generate_proof(c_, r, PrivateKey.to_point(mint_privkey))
+
+      assert Point.serialize_public_key(c) ==
+               "03d2e8a90ebe71819a9e76ce535de7a622ba302c639675608b539dfac2f60afb96"
+    end
+  end
+end

--- a/test/cashu_test.exs
+++ b/test/cashu_test.exs
@@ -1,7 +1,93 @@
 defmodule CashuTest do
-  use ExUnit.Case
+  alias Bitcoinex.Secp256k1
+  use ExUnit.Case, async: true
 
-  alias Cashu.TokenV3
-  alias Cashu.ProofV3
+  describe "create_output/3" do
+    test "succeeds for multiple inputs" do
+      secrets = [
+        "99323811477239c9ac8797be8bc701f6c88b8129",
+        "88aec2f16cfb616748e375f17260310895c3383d",
+        "a7edf5f59cf413bce680d4f6289ee51953a97d26",
+        "6d2e892270a4ffd2e01eb8b9003496d90d6be34c"
+      ]
 
+      blinding_factor_hexes = [
+        "afe42aafc36b237a4cef6d14d9968de5f97cb1ea5c9450eef147e9d8f8f92d16",
+        "02ce638c48e1eb1d4d820c9d72cd976df731e7d8527a59032ffa89642ea2e370",
+        "9ff729a07f14babfcde230a8357ca88fb1f526e83d01306b6f0e659583474fe9",
+        "ceb4bd807629aaf7bdc13af20badbd29ab6c998c4211ac053433fc4d1cd1a922"
+      ]
+
+      b_primes = [
+        "02d2134b1f5378d123ca044ea72294a5b9654f4f28a2efce568d3c278215a991ae",
+        "02ce221987430bf129289cf2342ef4e561e8513c187e45d06b5869623e08c32e52",
+        "02e30e74f985c929ed1eb68e634c2e067dbf0d053ae6e1fe1a313c86176a7d8d24",
+        "022a606493a5019a548f3db0fd9ef558525762254ac0bb467ad4d6fd573025b941"
+      ]
+
+      [secrets, blinding_factor_hexes, b_primes]
+      |> Enum.zip()
+      |> Enum.each(fn {secret, blinding_factor_hex, b_prime} ->
+        output = Cashu.create_output(secret, 1, blinding_factor_hex, "test_keyset")
+
+        assert output.b_prime == b_prime
+        assert output.amount == 1
+        assert output.id == "test_keyset"
+        assert output.secret == secret
+      end)
+    end
+  end
+
+  describe "create_proof/5" do
+    test "suceeds as well" do
+      secrets = [
+        "0e2744787ceb6b2c3c3010c5f43f8716d21e984b",
+        "e6a0cc3a68d65ed69da8c8bff62e0c6705fa1175",
+        "6409e4c036eeef974f3ae0639f591818a62c9d6c",
+        "61a295e98804216d810828f181d4d63080f68a0d"
+      ]
+
+      blinding_factors = [
+        "9666359ba06b55cf83dbc3e07f72401152496306f4e435b9ec101f8d033d7f4c",
+        "438b0fb011252446554a0b13e4501be4af30f33040f0bb476c2f871669583184",
+        "9fc1029028b4759ae17189f9b6f598216c2f25da5f8f61cb9a5a819539a40f27",
+        "5cdea958def4b975532bf0b40827f1a294da7e4dc93b7d5d6976267e83139a06"
+      ]
+
+      mint_privkey = [
+        "534db01882fc438cbcf607788ab0273e4db939e3d518303fc8bfd59a6caa766c",
+        "09c7e5c441e7bbf41d7b731ac3213852c118768fc58487cc01334dbda79436d4",
+        "562833c44cfaede593f55999f180b14f1fe8cba35238bcbe3dbbd8816711318d",
+        "58651e5848d1342fb82c0b69e0dd6c9adb618e157bd5a6dff341647477838792"
+      ]
+
+      signatures = [
+        "02f6b0bda857f3a0665074a02609fa3040634c6208eed7cb205d120220ab576dd0",
+        "033aec27cbeb0a2aa9bcd3aefe51dce0820151a15ac15d470e33634a669cef3bf0",
+        "022cd526799b66fbb26f3a1008d398826cec59e36de6c8df8e061bf858756a62db",
+        "026064e4a349cf84bd5844094b51fdb97cb9ce7ac104d8c2324ce89249cdce38db"
+      ]
+
+      [secrets, blinding_factors, mint_privkey, signatures]
+      |> Enum.zip()
+      |> Enum.each(fn {secret, blinding_factor, mint_privkey, signature} ->
+        keyset_id = "test_keyset"
+
+        {:ok, mint_privkey} = mint_privkey |> String.to_integer(16) |> Secp256k1.PrivateKey.new()
+        output = Cashu.create_output(secret, 1, blinding_factor, keyset_id)
+        promise = Cashu.sign_output(output.b_prime, 1, keyset_id, mint_privkey)
+
+        mint_pubkey =
+          Secp256k1.PrivateKey.to_point(mint_privkey) |> Secp256k1.Point.serialize_public_key()
+
+        proof =
+          Cashu.create_proof(promise.c_prime, blinding_factor, secret, 1, keyset_id, mint_pubkey)
+
+        assert proof.amount == 1
+        assert proof.keyset_id == keyset_id
+        assert proof.secret == secret
+        assert proof.signature == signature
+      end)
+    end
+  end
 end

--- a/test/nut00_test.exs
+++ b/test/nut00_test.exs
@@ -44,7 +44,10 @@ defmodule BDHKETest do
 
   describe "Blinded messages" do
     test "test case 01" do
-      x = "d341ee4871f1f889041e63cf0d3823c713eea6aff01e80f1719f08f9e5be98f6"
+      x =
+        "d341ee4871f1f889041e63cf0d3823c713eea6aff01e80f1719f08f9e5be98f6"
+        |> Base.decode16!(case: :lower)
+
       r = "99fce58439fc37412ab3468b73db0569322588f62fb3a49182d67e23d877824a"
 
       assert {:ok, point, _} = BDHKE.blind_point(x, r)
@@ -54,13 +57,36 @@ defmodule BDHKETest do
     end
 
     test "test case 02" do
-      x = "f1aaf16c2239746f369572c0784d9dd3d032d952c2d992175873fb58fae31a60"
+      x =
+        "f1aaf16c2239746f369572c0784d9dd3d032d952c2d992175873fb58fae31a60"
+        |> Base.decode16!(case: :lower)
+
       r = "f78476ea7cc9ade20f9e05e58a804cf19533f03ea805ece5fee88c8e2874ba50"
 
       assert {:ok, point, _} = BDHKE.blind_point(x, r)
 
       assert Point.serialize_public_key(point) ==
                "029bdf2d716ee366eddf599ba252786c1033f47e230248a4612a5670ab931f1763"
+    end
+
+    test "test case in nutshell" do
+      x = "test_message"
+      r = "0000000000000000000000000000000000000000000000000000000000000001"
+
+      assert {:ok, point, _} = BDHKE.blind_point(x, r)
+
+      assert Point.serialize_public_key(point) ==
+               "025cc16fe33b953e2ace39653efb3e7a7049711ae1d8a2f7a9108753f1cdea742b"
+    end
+
+    test "test case 03" do
+      x = "b0065e80d7ad2540e85815868287011a767a5f724838d43fc550cdf3b08b30ad"
+      r = "c954f58a9a9ffa11a7cb1cdb4178dad8661a33651a9ee397b682078241826ad4"
+
+      {:ok, point, _} = BDHKE.blind_point(x, r)
+
+      assert Point.serialize_public_key(point) ==
+               "0391127366eddb1e2f6a717374e4b6804fa0fc9fd394780140d0dd9bb3a8121643"
     end
   end
 
@@ -83,6 +109,40 @@ defmodule BDHKETest do
 
       assert Point.serialize_public_key(c_) ==
                "0398bc70ce8184d27ba89834d19f5199c84443c31131e48d3c1214db24247d005d"
+    end
+
+    test "test case in nutshell" do
+      assert {:ok, b_, _} =
+               BDHKE.blind_point(
+                 "test_message",
+                 "0000000000000000000000000000000000000000000000000000000000000001"
+               )
+
+      b_ = Point.serialize_public_key(b_)
+
+      mint_priv_key = "0000000000000000000000000000000000000000000000000000000000000001"
+
+      assert {:ok, c_, _, _} = BDHKE.sign_blinded_point(b_, mint_priv_key)
+
+      assert Point.serialize_public_key(c_) ==
+               "025cc16fe33b953e2ace39653efb3e7a7049711ae1d8a2f7a9108753f1cdea742b"
+    end
+
+    test "test case in 01" do
+      assert {:ok, b_, _} =
+               BDHKE.blind_point(
+                 "17176f1eb2604c283c0c50eb2232fcaee7e11a18431b493c00ef675fbb433a0f",
+                 "b41576276b780b9467a634a02d21e14d0ecec280be82b14444764177030c6d81"
+               )
+
+      b_ = Point.serialize_public_key(b_)
+
+      mint_priv_key = "c792bf68fa82a5002348fa0e58e4dd201f5910231f4e08271924699c9268177a"
+
+      assert {:ok, c_, _, _} = BDHKE.sign_blinded_point(b_, mint_priv_key)
+
+      assert Point.serialize_public_key(c_) ==
+               "02f808cc3ba75657fa591a43fce914297eb993fe7cea34e8b5438c5024d8ad4069"
     end
   end
 


### PR DESCRIPTION
Fix a few issues with the Cashu module and add tests for creating outputs and generating proofs.

The test vectors were created using nutshell.

See: https://gist.github.com/kazluu/2bfee3d4689eb726215949be22303994